### PR TITLE
Stub for a Remainder class [DO-NOT-MERGE]

### DIFF
--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -1838,3 +1838,7 @@ class FunctionCall(Token, Expr):
 
     _construct_name = String
     _construct_function_args = staticmethod(lambda args: Tuple(*args))
+
+
+class Remainder(Token):
+    __slots__ = ('numerator', 'denominator')

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -303,6 +303,11 @@ def test_sympy__codegen__ast__FunctionDefinition():
     assert _test_args(FunctionDefinition(real, 'pwer', [inp_x], [Assignment(x, x**2)]))
 
 
+def test_sympy__codegen__ast__Remainder():
+    from sympy.codegen.ast import Remainder
+    assert _test_args(Remainder(x, y))
+
+
 def test_sympy__codegen__ast__Return():
     from sympy.codegen.ast import Return
     assert _test_args(Return(x))

--- a/sympy/printing/c.py
+++ b/sympy/printing/c.py
@@ -70,6 +70,7 @@ known_functions_C99 = dict(known_functions_C89, **{
     "atanh": "atanh",
     "erf": "erf",
     "gamma": "tgamma",
+    "Remainder": "remainder",
 })
 
 # These are the core reserved words in the C language. Taken from:
@@ -289,6 +290,14 @@ class C89CodePrinter(CodePrinter):
         else:
             return '%spow%s(%s, %s)' % (self._ns, suffix, self._print(expr.base),
                                    self._print(expr.exp))
+
+    def _print_Remainder(self, expr):
+        num, den = expr.args
+        if num.is_integer and den.is_integer:
+            snum, sden = [self.parenthesize(arg, PREC) for arg in expr.args]
+            return f"{snum} % {sden}"
+        return self._print_math_func(expr, known='remainder')
+
 
     def _print_Mod(self, expr):
         num, den = expr.args
@@ -672,6 +681,7 @@ class C99CodePrinter(C89CodePrinter):
         return 'NAN'
 
     # tgamma was already covered by 'known_functions' dict
+
 
     @requires(headers={'math.h'}, libraries={'m'})
     @_as_macro_if_defined


### PR DESCRIPTION
This is not currently working, it is just a stub. At the time of writing I just realized that C99's `remainder` function can return negative numbers for positive arguments. But right now I have run out of time, but I thought I could push these changes in case they are of any value to you.

xref: #22089